### PR TITLE
Implement Teardown for net

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/*.js"
 			],
-			"preLaunchTask": "${defaultBuildTask}"
+			"preLaunchTask": "build"
 		},
 		{
 			"name": "Run Mock Extension",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,24 +4,18 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"type": "npm",
-			"script": "vscode:prepublish",
+			"type": "shell",
+			"command": "npm run vscode:prepublish",
 			"presentation": {
 				"reveal": "never"
 			},
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
+			"label": "build"
 		},
 		{
-			"type": "npm",
-			"script": "vscode:prepublish",
+			"type": "shell",
+			"command": "npm run vscode:prepublish",
 			"presentation": {
 				"reveal": "never"
-			},
-			"group": {
-				"kind": "build",
 			},
 			"options": {
 				"env": {

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -40,5 +40,14 @@
     "Edit Filters of {0}": "Modification des filtres de {0}",
     "Which filter to select ?": "Quel filtre est à sélectionner ?",
     "The value is incorrect. It should be a valid JSON": "La valeur est incorrecte. Cela doit être un JSON valide.",
+    "Do you want to tear down the net {0} ?": "Voulez-vous détruire le Net {0} ?",
+    "The net {0} has been torn down": "Le Net {0} a été détruit",
+    "Error while tearing down the net {0}: {1}": "Erreur lors de la destruction du Net {0}: {1}",
+    "Teardown Net '{0}'": "Destruction de Net '{0}'",
+    "{0} resources to clean...": "{0} ressources à nettoyer",
+    "Cancelled by the user": "Annulé par l'utilisateur",
+    "Cleaning {0}...": "Nettoyage de {0}...",
+    "Error while cleaning {0}: {1}": "Erreur lors du nettoyage de {0}: {1}",
+    "Succeed to clean {0}": "Succès du nettoyage de {0}",
     "Get": "Récupération"
 }

--- a/package.json
+++ b/package.json
@@ -182,6 +182,11 @@
         "command": "osc.deleteSubresource",
         "title": "%osc.deleteSubresource%",
         "category": "osc-viewer"
+      },
+      {
+        "command": "osc.teardownNet",
+        "title": "%osc.teardownNet%",
+        "category": "osc-viewer"
       }
     ],
     "viewsContainers": {
@@ -266,6 +271,11 @@
           "command": "osc.deleteSubresource",
           "when": "view == profile && viewItem =~ /subresourcenode/",
           "group": "oscinteract@5"
+        },
+        {
+          "command": "osc.teardownNet",
+          "when": "view == profile && viewItem =~ /netresourcenode/",
+          "group": "oscinteract@6"
         },
         {
           "command": "osc.showConsoleLogs",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -25,5 +25,6 @@
     "osc.resetFilters": "Réinitialiser les filters",
     "osc.unlinkResource": "Dissocier",
     "osc.deleteSubresource": "Supprimer les sous-resources",
+    "osc.teardownNet": "Détruire",
     "viewsWelcome.text": "Pour utiliser l'extension 3DS Outscale, vous devez configurer des profiles dans le fichier de configuration.\n[Ouvrir le fichier de configuration](command:profile.configure)\n[Ajouter un profile](command:profile.addEntry)\n"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -25,5 +25,6 @@
     "osc.resetFilters": "Reset Filters",
     "osc.unlinkResource": "Unlink",
     "osc.deleteSubresource": "Delete Subresource",
+    "osc.teardownNet": "Tear down",
     "viewsWelcome.text": "In order to use 3DS Outscale plugin, you have to configure profiles the configuration file.\n[Open configuration file](command:profile.configure)\n[Add a profile](command:profile.addEntry)\n"
 }

--- a/src/cloud/accesskeys.ts
+++ b/src/cloud/accesskeys.ts
@@ -27,7 +27,7 @@ export function getAccessKeys(profile: Profile, filters?: FiltersAccessKeys): Pr
 }
 
 // Retrieve a specific item of the resource AccessKey
-export function getAccessKey(profile: Profile, resourceId: string): Promise<osc.AccessKey | string> {
+export function getAccessKey(profile: Profile, resourceId: string): Promise<osc.AccessKey | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadAccessKeysOperationRequest = {
         readAccessKeysRequest: {
@@ -41,7 +41,7 @@ export function getAccessKey(profile: Profile, resourceId: string): Promise<osc.
     return api.readAccessKeys(readParameters)
         .then((res: osc.ReadAccessKeysResponse) => {
             if (res.accessKeys === undefined || res.accessKeys.length === 0) {
-                return {};
+                return undefined;
             }
             return res.accessKeys[0];
         }, (err_: any) => {

--- a/src/cloud/account.ts
+++ b/src/cloud/account.ts
@@ -22,7 +22,7 @@ export function getAccounts(profile: Profile): Promise<Array<osc.Account> | stri
         });
 }
 
-export function getAccount(profile: Profile, _: string): Promise<osc.Account | string> {
+export function getAccount(profile: Profile, _: string): Promise<osc.Account | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadAccountsOperationRequest = {
         readAccountsRequest: {}
@@ -32,7 +32,7 @@ export function getAccount(profile: Profile, _: string): Promise<osc.Account | s
     return api.readAccounts(readParameters)
         .then((res: osc.ReadAccountsResponse) => {
             if (res.accounts === undefined || res.accounts.length === 0) {
-                return {};
+                return undefined;
             }
             return res.accounts[0];
         }, (err_: any) => {

--- a/src/cloud/apiaccessrules.ts
+++ b/src/cloud/apiaccessrules.ts
@@ -27,7 +27,7 @@ export function getApiAccessRules(profile: Profile, filters?: FiltersApiAccessRu
 }
 
 // Retrieve a specific item of the resource ApiAccessRule
-export function getApiAccessRule(profile: Profile, resourceId: string): Promise<osc.ApiAccessRule | string> {
+export function getApiAccessRule(profile: Profile, resourceId: string): Promise<osc.ApiAccessRule | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadApiAccessRulesOperationRequest = {
         readApiAccessRulesRequest: {
@@ -41,7 +41,7 @@ export function getApiAccessRule(profile: Profile, resourceId: string): Promise<
     return api.readApiAccessRules(readParameters)
         .then((res: osc.ReadApiAccessRulesResponse) => {
             if (res.apiAccessRules === undefined || res.apiAccessRules.length === 0) {
-                return {};
+                return undefined;
             }
             return res.apiAccessRules[0];
         }, (err_: any) => {

--- a/src/cloud/cas.ts
+++ b/src/cloud/cas.ts
@@ -27,7 +27,7 @@ export function getCas(profile: Profile, filters?: FiltersCa): Promise<Array<osc
 }
 
 // Retrieve a specific item of the resource Ca
-export function getCa(profile: Profile, resourceId: string): Promise<osc.Ca | string> {
+export function getCa(profile: Profile, resourceId: string): Promise<osc.Ca | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadCasOperationRequest = {
         readCasRequest: {
@@ -41,7 +41,7 @@ export function getCa(profile: Profile, resourceId: string): Promise<osc.Ca | st
     return api.readCas(readParameters)
         .then((res: osc.ReadCasResponse) => {
             if (res.cas === undefined || res.cas.length === 0) {
-                return {};
+                return undefined;
             }
             return res.cas[0];
         }, (err_: any) => {

--- a/src/cloud/clientgateways.ts
+++ b/src/cloud/clientgateways.ts
@@ -27,7 +27,7 @@ export function getClientGateways(profile: Profile, filters?: FiltersClientGatew
 }
 
 // Retrieve a specific item of the resource ClientGateway
-export function getClientGateway(profile: Profile, resourceId: string): Promise<osc.ClientGateway | string> {
+export function getClientGateway(profile: Profile, resourceId: string): Promise<osc.ClientGateway | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadClientGatewaysOperationRequest = {
         readClientGatewaysRequest: {
@@ -41,7 +41,7 @@ export function getClientGateway(profile: Profile, resourceId: string): Promise<
     return api.readClientGateways(readParameters)
         .then((res: osc.ReadClientGatewaysResponse) => {
             if (res.clientGateways === undefined || res.clientGateways.length === 0) {
-                return {};
+                return undefined;
             }
             return res.clientGateways[0];
         }, (err_: any) => {

--- a/src/cloud/cloud.ts
+++ b/src/cloud/cloud.ts
@@ -4,6 +4,7 @@ import * as fetch from "cross-fetch";
 import * as crypto from "crypto";
 import { Profile } from "../flat/node";
 import { ResponseError } from "outscale-api";
+import { OutputChannel } from "../logs/output_channel";
 
 global.Headers = fetch.Headers;
 global.crypto = crypto.webcrypto;
@@ -25,6 +26,8 @@ export async function handleRejection(err: any): Promise<string> {
         const status = err.response.status;
         const value = await err.response.json();
         console.error("[osc-viewer]", err.response.url, JSON.stringify(value));
+        const outputChannel = OutputChannel.getInstance();
+        outputChannel.appendLine(`[osc-viewer] ${err.response.url} ${JSON.stringify(value)}`);
         return `${status} ${err.response.statusText}`;
     }
     return err.toString();

--- a/src/cloud/dhcpoptions.ts
+++ b/src/cloud/dhcpoptions.ts
@@ -27,7 +27,7 @@ export function getDhcpOptions(profile: Profile, filters?: FiltersDhcpOptions): 
 }
 
 // Retrieve a specific item of the resource DhcpOption
-export function getDhcpOption(profile: Profile, resourceId: string): Promise<osc.DhcpOptionsSet | string> {
+export function getDhcpOption(profile: Profile, resourceId: string): Promise<osc.DhcpOptionsSet | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadDhcpOptionsOperationRequest = {
         readDhcpOptionsRequest: {
@@ -41,7 +41,7 @@ export function getDhcpOption(profile: Profile, resourceId: string): Promise<osc
     return api.readDhcpOptions(readParameters)
         .then((res: osc.ReadDhcpOptionsResponse) => {
             if (res.dhcpOptionsSets === undefined || res.dhcpOptionsSets.length === 0) {
-                return {};
+                return undefined;
             }
             return res.dhcpOptionsSets[0];
         }, (err_: any) => {

--- a/src/cloud/directlinkinterfaces.ts
+++ b/src/cloud/directlinkinterfaces.ts
@@ -27,7 +27,7 @@ export function getDirectLinkInterfaces(profile: Profile, filters?: FiltersDirec
 }
 
 // Retrieve a specific item of the resource DirectLinkInterface
-export function getDirectLinkInterface(profile: Profile, resourceId: string): Promise<osc.DirectLinkInterfaces | string> {
+export function getDirectLinkInterface(profile: Profile, resourceId: string): Promise<osc.DirectLinkInterfaces | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadDirectLinkInterfacesOperationRequest = {
         readDirectLinkInterfacesRequest: {
@@ -41,7 +41,7 @@ export function getDirectLinkInterface(profile: Profile, resourceId: string): Pr
     return api.readDirectLinkInterfaces(readParameters)
         .then((res: osc.ReadDirectLinkInterfacesResponse) => {
             if (res.directLinkInterfaces === undefined || res.directLinkInterfaces.length === 0) {
-                return {};
+                return undefined;
             }
             return res.directLinkInterfaces[0];
         }, (err_: any) => {

--- a/src/cloud/directlinks.ts
+++ b/src/cloud/directlinks.ts
@@ -27,7 +27,7 @@ export function getDirectLinks(profile: Profile, filters?: FiltersDirectLink): P
 }
 
 // Retrieve a specific item of the resource DirectLink
-export function getDirectLink(profile: Profile, resourceId: string): Promise<osc.DirectLink | string> {
+export function getDirectLink(profile: Profile, resourceId: string): Promise<osc.DirectLink | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadDirectLinksOperationRequest = {
         readDirectLinksRequest: {
@@ -41,7 +41,7 @@ export function getDirectLink(profile: Profile, resourceId: string): Promise<osc
     return api.readDirectLinks(readParameters)
         .then((res: osc.ReadDirectLinksResponse) => {
             if (res.directLinks === undefined || res.directLinks.length === 0) {
-                return {};
+                return undefined;
             }
             return res.directLinks[0];
         }, (err_: any) => {

--- a/src/cloud/flexiblegpus.ts
+++ b/src/cloud/flexiblegpus.ts
@@ -27,7 +27,7 @@ export function getFlexibleGpus(profile: Profile, filters?: FiltersFlexibleGpu):
 }
 
 // Retrieve a specific item of the resource FlexibleGpu
-export function getFlexibleGpu(profile: Profile, resourceId: string): Promise<osc.FlexibleGpu | string> {
+export function getFlexibleGpu(profile: Profile, resourceId: string): Promise<osc.FlexibleGpu | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadFlexibleGpusOperationRequest = {
         readFlexibleGpusRequest: {
@@ -41,7 +41,7 @@ export function getFlexibleGpu(profile: Profile, resourceId: string): Promise<os
     return api.readFlexibleGpus(readParameters)
         .then((res: osc.ReadFlexibleGpusResponse) => {
             if (res.flexibleGpus === undefined || res.flexibleGpus.length === 0) {
-                return {};
+                return undefined;
             }
             return res.flexibleGpus[0];
         }, (err_: any) => {

--- a/src/cloud/images.ts
+++ b/src/cloud/images.ts
@@ -26,7 +26,7 @@ export function getOMIs(profile: Profile, filters?: osc.FiltersImage): Promise<A
 }
 
 // Retrieve a specific item of the resource Image
-export function getOMI(profile: Profile, resourceId: string): Promise<osc.Image | string> {
+export function getOMI(profile: Profile, resourceId: string): Promise<osc.Image | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadImagesOperationRequest = {
         readImagesRequest: {
@@ -40,7 +40,7 @@ export function getOMI(profile: Profile, resourceId: string): Promise<osc.Image 
     return api.readImages(readParameters)
         .then((res: osc.ReadImagesResponse) => {
             if (res.images === undefined || res.images.length === 0) {
-                return {};
+                return undefined;
             }
             return res.images[0];
         }, (err_: any) => {

--- a/src/cloud/internetservices.ts
+++ b/src/cloud/internetservices.ts
@@ -27,7 +27,7 @@ export function getInternetServices(profile: Profile, filters?: FiltersInternetS
 }
 
 // Retrieve a specific item of the resource InternetService
-export function getInternetService(profile: Profile, resourceId: string): Promise<osc.InternetService | string> {
+export function getInternetService(profile: Profile, resourceId: string): Promise<osc.InternetService | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadInternetServicesOperationRequest = {
         readInternetServicesRequest: {
@@ -41,7 +41,7 @@ export function getInternetService(profile: Profile, resourceId: string): Promis
     return api.readInternetServices(readParameters)
         .then((res: osc.ReadInternetServicesResponse) => {
             if (res.internetServices === undefined || res.internetServices.length === 0) {
-                return {};
+                return undefined;
             }
             return res.internetServices[0];
         }, (err_: any) => {

--- a/src/cloud/keypairs.ts
+++ b/src/cloud/keypairs.ts
@@ -27,7 +27,7 @@ export function getKeypairs(profile: Profile, filters?: FiltersKeypair): Promise
 }
 
 // Retrieve a specific item of the resource Keypair
-export function getKeypair(profile: Profile, resourceId: string): Promise<osc.Keypair | string> {
+export function getKeypair(profile: Profile, resourceId: string): Promise<osc.Keypair | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadKeypairsOperationRequest = {
         readKeypairsRequest: {
@@ -41,7 +41,7 @@ export function getKeypair(profile: Profile, resourceId: string): Promise<osc.Ke
     return api.readKeypairs(readParameters)
         .then((res: osc.ReadKeypairsResponse) => {
             if (res.keypairs === undefined || res.keypairs.length === 0) {
-                return {};
+                return undefined;
             }
             return res.keypairs[0];
         }, (err_: any) => {

--- a/src/cloud/loadbalancers.ts
+++ b/src/cloud/loadbalancers.ts
@@ -49,6 +49,34 @@ export function getLoadBalancer(profile: Profile, resourceId: string): Promise<o
         });
 }
 
+// Retrieve all items of the resource LoadBalancer in a specific Subnet
+export function getLoadBalancersInNet(profile: Profile, netId: string): Promise<Array<osc.LoadBalancer> | string> {
+    const config = getConfig(profile);
+    const readParameters: osc.ReadLoadBalancersOperationRequest = {
+    };
+
+    const api = new osc.LoadBalancerApi(config);
+    return api.readLoadBalancers(readParameters)
+        .then((res: osc.ReadLoadBalancersResponse) => {
+            if (res.loadBalancers === undefined || res.loadBalancers.length === 0) {
+                return [];
+            }
+            const targetRes: Array<osc.LoadBalancer> = [];
+            for (const lbu of res.loadBalancers) {
+                if (typeof lbu.netId === 'undefined') {
+                    continue;
+                }
+
+                if (lbu.netId === netId) {
+                    targetRes.push(lbu);
+                }
+            }
+            return targetRes;
+        }, (err_: any) => {
+            return handleRejection(err_);
+        });
+}
+
 // Delete a specific item the resource LoadBalancer
 export function deleteLoadBalancer(profile: Profile, resourceId: string): Promise<string | undefined> {
     const config = getConfig(profile);

--- a/src/cloud/loadbalancers.ts
+++ b/src/cloud/loadbalancers.ts
@@ -27,7 +27,7 @@ export function getLoadBalancers(profile: Profile, filters?: FiltersLoadBalancer
 }
 
 // Retrieve a specific item of the resource LoadBalancer
-export function getLoadBalancer(profile: Profile, resourceId: string): Promise<osc.LoadBalancer | string> {
+export function getLoadBalancer(profile: Profile, resourceId: string): Promise<osc.LoadBalancer | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadLoadBalancersOperationRequest = {
         readLoadBalancersRequest: {
@@ -41,7 +41,7 @@ export function getLoadBalancer(profile: Profile, resourceId: string): Promise<o
     return api.readLoadBalancers(readParameters)
         .then((res: osc.ReadLoadBalancersResponse) => {
             if (res.loadBalancers === undefined || res.loadBalancers.length === 0) {
-                return {};
+                return undefined;
             }
             return res.loadBalancers[0];
         }, (err_: any) => {

--- a/src/cloud/natservices.ts
+++ b/src/cloud/natservices.ts
@@ -27,7 +27,7 @@ export function getNatServices(profile: Profile, filters?: FiltersNatService): P
 }
 
 // Retrieve a specific item of the resource NatService
-export function getNatService(profile: Profile, resourceId: string): Promise<osc.NatService | string> {
+export function getNatService(profile: Profile, resourceId: string): Promise<osc.NatService | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadNatServicesOperationRequest = {
         readNatServicesRequest: {
@@ -41,7 +41,7 @@ export function getNatService(profile: Profile, resourceId: string): Promise<osc
     return api.readNatServices(readParameters)
         .then((res: osc.ReadNatServicesResponse) => {
             if (res.natServices === undefined || res.natServices.length === 0) {
-                return {};
+                return undefined;
             }
             return res.natServices[0];
         }, (err_: any) => {

--- a/src/cloud/netaccesspoints.ts
+++ b/src/cloud/netaccesspoints.ts
@@ -27,7 +27,7 @@ export function getNetAccessPoints(profile: Profile, filters?: FiltersNetAccessP
 }
 
 // Retrieve a specific item of the resource NetAccessPoint
-export function getNetAccessPoint(profile: Profile, resourceId: string): Promise<osc.NetAccessPoint | string> {
+export function getNetAccessPoint(profile: Profile, resourceId: string): Promise<osc.NetAccessPoint | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadNetAccessPointsOperationRequest = {
         readNetAccessPointsRequest: {
@@ -41,7 +41,7 @@ export function getNetAccessPoint(profile: Profile, resourceId: string): Promise
     return api.readNetAccessPoints(readParameters)
         .then((res: osc.ReadNetAccessPointsResponse) => {
             if (res.netAccessPoints === undefined || res.netAccessPoints.length === 0) {
-                return {};
+                return undefined;
             }
             return res.netAccessPoints[0];
         }, (err_: any) => {

--- a/src/cloud/netpeerings.ts
+++ b/src/cloud/netpeerings.ts
@@ -27,7 +27,7 @@ export function getNetPeerings(profile: Profile, filters?: FiltersNetPeering): P
 }
 
 // Retrieve a specific item of the resource NetPeering
-export function getNetPeering(profile: Profile, resourceId: string): Promise<osc.NetPeering | string> {
+export function getNetPeering(profile: Profile, resourceId: string): Promise<osc.NetPeering | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadNetPeeringsOperationRequest = {
         readNetPeeringsRequest: {
@@ -41,7 +41,7 @@ export function getNetPeering(profile: Profile, resourceId: string): Promise<osc
     return api.readNetPeerings(readParameters)
         .then((res: osc.ReadNetPeeringsResponse) => {
             if (res.netPeerings === undefined || res.netPeerings.length === 0) {
-                return {};
+                return undefined;
             }
             return res.netPeerings[0];
         }, (err_: any) => {

--- a/src/cloud/nets.ts
+++ b/src/cloud/nets.ts
@@ -27,7 +27,7 @@ export function getNets(profile: Profile, filters?: FiltersNet): Promise<Array<o
 }
 
 // Retrieve a specific item of the resource Net
-export function getNet(profile: Profile, resourceId: string): Promise<osc.Net | string> {
+export function getNet(profile: Profile, resourceId: string): Promise<osc.Net | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadNetsOperationRequest = {
         readNetsRequest: {
@@ -41,7 +41,7 @@ export function getNet(profile: Profile, resourceId: string): Promise<osc.Net | 
     return api.readNets(readParameters)
         .then((res: osc.ReadNetsResponse) => {
             if (res.nets === undefined || res.nets.length === 0) {
-                return {};
+                return undefined;
             }
             return res.nets[0];
         }, (err_: any) => {

--- a/src/cloud/nics.ts
+++ b/src/cloud/nics.ts
@@ -27,7 +27,7 @@ export function getNics(profile: Profile, filters?: FiltersNic): Promise<Array<o
 }
 
 // Retrieve a specific item of the resource Nic
-export function getNic(profile: Profile, resourceId: string): Promise<osc.Nic | string> {
+export function getNic(profile: Profile, resourceId: string): Promise<osc.Nic | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadNicsOperationRequest = {
         readNicsRequest: {
@@ -41,7 +41,7 @@ export function getNic(profile: Profile, resourceId: string): Promise<osc.Nic | 
     return api.readNics(readParameters)
         .then((res: osc.ReadNicsResponse) => {
             if (res.nics === undefined || res.nics.length === 0) {
-                return {};
+                return undefined;
             }
             return res.nics[0];
         }, (err_: any) => {

--- a/src/cloud/publicips.ts
+++ b/src/cloud/publicips.ts
@@ -25,7 +25,7 @@ export function getExternalIPs(profile: Profile, filters?: FiltersPublicIp): Pro
         });
 }
 
-export function getExternalIP(profile: Profile, publicIpId: string): Promise<osc.PublicIp | string> {
+export function getExternalIP(profile: Profile, publicIpId: string): Promise<osc.PublicIp | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadPublicIpsOperationRequest = {
         readPublicIpsRequest: {
@@ -39,7 +39,7 @@ export function getExternalIP(profile: Profile, publicIpId: string): Promise<osc
     return api.readPublicIps(readParameters)
         .then((res: osc.ReadPublicIpsResponse) => {
             if (res.publicIps === undefined || res.publicIps.length === 0) {
-                return {};
+                return undefined;
             }
             return res.publicIps[0];
         }, (err_: any) => {

--- a/src/cloud/routetables.ts
+++ b/src/cloud/routetables.ts
@@ -27,7 +27,7 @@ export function getRouteTables(profile: Profile, filters?: FiltersRouteTable): P
 }
 
 // Retrieve a specific item of the resource RouteTable
-export function getRouteTable(profile: Profile, resourceId: string): Promise<osc.RouteTable | string> {
+export function getRouteTable(profile: Profile, resourceId: string): Promise<osc.RouteTable | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadRouteTablesOperationRequest = {
         readRouteTablesRequest: {
@@ -41,7 +41,7 @@ export function getRouteTable(profile: Profile, resourceId: string): Promise<osc
     return api.readRouteTables(readParameters)
         .then((res: osc.ReadRouteTablesResponse) => {
             if (res.routeTables === undefined || res.routeTables.length === 0) {
-                return {};
+                return undefined;
             }
             return res.routeTables[0];
         }, (err_: any) => {

--- a/src/cloud/securitygroups.ts
+++ b/src/cloud/securitygroups.ts
@@ -27,7 +27,7 @@ export function getSecurityGroups(profile: Profile, filters?: FiltersSecurityGro
 }
 
 // Retrieve a specific item of the resource SecurityGroup
-export function getSecurityGroup(profile: Profile, resourceId: string): Promise<osc.SecurityGroup | string> {
+export function getSecurityGroup(profile: Profile, resourceId: string): Promise<osc.SecurityGroup | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadSecurityGroupsOperationRequest = {
         readSecurityGroupsRequest: {
@@ -41,7 +41,7 @@ export function getSecurityGroup(profile: Profile, resourceId: string): Promise<
     return api.readSecurityGroups(readParameters)
         .then((res: osc.ReadSecurityGroupsResponse) => {
             if (res.securityGroups === undefined || res.securityGroups.length === 0) {
-                return {};
+                return undefined;
             }
             return res.securityGroups[0];
         }, (err_: any) => {

--- a/src/cloud/snapshots.ts
+++ b/src/cloud/snapshots.ts
@@ -27,7 +27,7 @@ export function getSnapshots(profile: Profile, filters?: FiltersSnapshot): Promi
 }
 
 // Retrieve a specific item of the resource Snapshot
-export function getSnapshot(profile: Profile, resourceId: string): Promise<osc.Snapshot | string> {
+export function getSnapshot(profile: Profile, resourceId: string): Promise<osc.Snapshot | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadSnapshotsOperationRequest = {
         readSnapshotsRequest: {
@@ -41,7 +41,7 @@ export function getSnapshot(profile: Profile, resourceId: string): Promise<osc.S
     return api.readSnapshots(readParameters)
         .then((res: osc.ReadSnapshotsResponse) => {
             if (res.snapshots === undefined || res.snapshots.length === 0) {
-                return {};
+                return undefined;
             }
             return res.snapshots[0];
         }, (err_: any) => {

--- a/src/cloud/subnets.ts
+++ b/src/cloud/subnets.ts
@@ -27,7 +27,7 @@ export function getSubnets(profile: Profile, filters?: FiltersSubnet): Promise<A
 }
 
 // Retrieve a specific item of the resource Subnet
-export function getSubnet(profile: Profile, resourceId: string): Promise<osc.Subnet | string> {
+export function getSubnet(profile: Profile, resourceId: string): Promise<osc.Subnet | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadSubnetsOperationRequest = {
         readSubnetsRequest: {
@@ -41,7 +41,7 @@ export function getSubnet(profile: Profile, resourceId: string): Promise<osc.Sub
     return api.readSubnets(readParameters)
         .then((res: osc.ReadSubnetsResponse) => {
             if (res.subnets === undefined || res.subnets.length === 0) {
-                return {};
+                return undefined;
             }
             return res.subnets[0];
         }, (err_: any) => {

--- a/src/cloud/virtualgateways.ts
+++ b/src/cloud/virtualgateways.ts
@@ -27,7 +27,7 @@ export function getVirtualGateways(profile: Profile, filters?: FiltersVirtualGat
 }
 
 // Retrieve a specific item of the resource VirtualGateway
-export function getVirtualGateway(profile: Profile, resourceId: string): Promise<osc.VirtualGateway | string> {
+export function getVirtualGateway(profile: Profile, resourceId: string): Promise<osc.VirtualGateway | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadVirtualGatewaysOperationRequest = {
         readVirtualGatewaysRequest: {
@@ -41,7 +41,7 @@ export function getVirtualGateway(profile: Profile, resourceId: string): Promise
     return api.readVirtualGateways(readParameters)
         .then((res: osc.ReadVirtualGatewaysResponse) => {
             if (res.virtualGateways === undefined || res.virtualGateways.length === 0) {
-                return {};
+                return undefined;
             }
             return res.virtualGateways[0];
         }, (err_: any) => {

--- a/src/cloud/vms.ts
+++ b/src/cloud/vms.ts
@@ -26,7 +26,7 @@ export function getVms(profile: Profile, filters?: FiltersVm): Promise<Array<osc
 }
 
 // Retrieve a specific item of the resource Vm
-export function getVm(profile: Profile, resourceId: string): Promise<osc.Vm | string> {
+export function getVm(profile: Profile, resourceId: string): Promise<osc.Vm | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadVmsOperationRequest = {
         readVmsRequest: {
@@ -40,7 +40,7 @@ export function getVm(profile: Profile, resourceId: string): Promise<osc.Vm | st
     return api.readVms(readParameters)
         .then((res: osc.ReadVmsResponse) => {
             if (res.vms === undefined || res.vms.length === 0) {
-                return {};
+                return undefined;
             }
             return res.vms[0];
         }, (err_: any) => {

--- a/src/cloud/vms.ts
+++ b/src/cloud/vms.ts
@@ -48,6 +48,33 @@ export function getVm(profile: Profile, resourceId: string): Promise<osc.Vm | un
         });
 }
 
+// Retrieve all items of the resource Vm in a specific Subnet
+export function getVmsInNet(profile: Profile, netId: string): Promise<Array<osc.Vm> | string> {
+    const config = getConfig(profile);
+    const readParameters: osc.ReadVmsOperationRequest = {
+    };
+
+    const api = new osc.VmApi(config);
+    return api.readVms(readParameters)
+        .then((res: osc.ReadVmsResponse) => {
+            if (res.vms === undefined || res.vms.length === 0) {
+                return [];
+            }
+            const targetVms: Array<osc.Vm> = [];
+            for (const vm of res.vms) {
+                if (typeof vm.netId === 'undefined') {
+                    continue;
+                }
+                if (vm.netId === netId) {
+                    targetVms.push(vm);
+                }
+            }
+            return targetVms;
+        }, (err_: any) => {
+            return handleRejection(err_);
+        });
+}
+
 export function getVmName(vm: osc.Vm): string {
     if (typeof vm.tags === "undefined") {
         return "";

--- a/src/cloud/volumes.ts
+++ b/src/cloud/volumes.ts
@@ -27,7 +27,7 @@ export function getVolumes(profile: Profile, filters?: FiltersVolume): Promise<A
 }
 
 // Retrieve a specific item of the resource Volume
-export function getVolume(profile: Profile, resourceId: string): Promise<osc.Volume | string> {
+export function getVolume(profile: Profile, resourceId: string): Promise<osc.Volume | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadVolumesOperationRequest = {
         readVolumesRequest: {
@@ -41,7 +41,7 @@ export function getVolume(profile: Profile, resourceId: string): Promise<osc.Vol
     return api.readVolumes(readParameters)
         .then((res: osc.ReadVolumesResponse) => {
             if (res.volumes === undefined || res.volumes.length === 0) {
-                return {};
+                return undefined;
             }
             return res.volumes[0];
         }, (err_: any) => {

--- a/src/cloud/vpnconnections.ts
+++ b/src/cloud/vpnconnections.ts
@@ -27,7 +27,7 @@ export function getVpnConnections(profile: Profile, filters?: FiltersVpnConnecti
 }
 
 // Retrieve a specific item of the resource VpnConnection
-export function getVpnConnection(profile: Profile, resourceId: string): Promise<osc.VpnConnection | string> {
+export function getVpnConnection(profile: Profile, resourceId: string): Promise<osc.VpnConnection | undefined | string> {
     const config = getConfig(profile);
     const readParameters: osc.ReadVpnConnectionsOperationRequest = {
         readVpnConnectionsRequest: {
@@ -41,7 +41,7 @@ export function getVpnConnection(profile: Profile, resourceId: string): Promise<
     return api.readVpnConnections(readParameters)
         .then((res: osc.ReadVpnConnectionsResponse) => {
             if (res.vpnConnections === undefined || res.vpnConnections.length === 0) {
-                return {};
+                return undefined;
             }
             return res.vpnConnections[0];
         }, (err_: any) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { DISABLE_FOLDER_PARAMETER, getConfigurationParameter, updateConfiguratio
 import { editFilters } from './config_file/action.editFilters';
 import { LinkResourceNode } from './flat/resources/types/node.resources.link';
 import { SubResourceNode } from './flat/resources/types/node.resources.subresource';
+import { NetResourceNode } from './flat/resources/node.resources.nets';
 
 function getMultipleSelection<T>(mainSelectedItem: T, allSelectedItems?: any[]): T[] {
     if (typeof allSelectedItems === 'undefined') {
@@ -240,6 +241,18 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showErrorMessage(vscode.l10n.t(`Error while deleting the subresource of {0}: {1}`, arg.getResourceName(), res));
             }
         });
+    });
+
+    vscode.commands.registerCommand('osc.teardownNet', async (arg: NetResourceNode) => {
+        showYesOrNoWindow(vscode.l10n.t(`Do you want to tear down the net {0} ?`, arg.getResourceName()), async () => {
+            const res = await arg.teardown();
+            if (typeof res === "undefined") {
+                vscode.window.showInformationMessage(vscode.l10n.t(`The net {0} has been torn down`, arg.getResourceName()));
+            } else {
+                vscode.window.showErrorMessage(vscode.l10n.t(`Error while tearing down the net {0}: {1}`, arg.getResourceName(), res));
+            }
+        });
+
     });
 
 }

--- a/src/flat/folders/simple/node.folder.accesskey.ts
+++ b/src/flat/folders/simple/node.folder.accesskey.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteAccessKey, getAccessKeys } from '../../../cloud/accesskeys';
+import { deleteAccessKey, getAccessKeys, getAccessKey } from '../../../cloud/accesskeys';
 import { FiltersAccessKeys, FiltersAccessKeysFromJSON } from 'outscale-api';
 
 export const ACCESSKEY_FOLDER_NAME = "Access Keys";
@@ -26,7 +26,7 @@ export class AccessKeysFolderNode extends FiltersFolderNode<FiltersAccessKeys> i
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.accessKeyId, "AccessKey", deleteAccessKey));
+                resources.push(new ResourceNode(this.profile, "", item.accessKeyId, "AccessKey", deleteAccessKey, getAccessKey));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.apiaccessrule.ts
+++ b/src/flat/folders/simple/node.folder.apiaccessrule.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteApiAccessRule, getApiAccessRules } from '../../../cloud/apiaccessrules';
+import { deleteApiAccessRule, getApiAccessRule, getApiAccessRules } from '../../../cloud/apiaccessrules';
 import { FiltersApiAccessRule, FiltersApiAccessRuleFromJSON } from 'outscale-api';
 
 export const APIACCESSRULES_FOLDER_NAME = "Api Access Rules";
@@ -26,7 +26,7 @@ export class ApiAccessRulesFolderNode extends FiltersFolderNode<FiltersApiAccess
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.apiAccessRuleId, "ApiAccessRule", deleteApiAccessRule));
+                resources.push(new ResourceNode(this.profile, "", item.apiAccessRuleId, "ApiAccessRule", deleteApiAccessRule, getApiAccessRule));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.ca.ts
+++ b/src/flat/folders/simple/node.folder.ca.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteCa, getCas } from '../../../cloud/cas';
+import { deleteCa, getCa, getCas } from '../../../cloud/cas';
 import { FiltersCa, FiltersCaFromJSON } from 'outscale-api';
 
 export const CA_FOLDER_NAME = "Cas";
@@ -26,7 +26,7 @@ export class CasFolderNode extends FiltersFolderNode<FiltersCa> implements Explo
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.caId, "Ca", deleteCa));
+                resources.push(new ResourceNode(this.profile, "", item.caId, "Ca", deleteCa, getCa));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.clientgateway.ts
+++ b/src/flat/folders/simple/node.folder.clientgateway.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteClientGateway, getClientGateways } from '../../../cloud/clientgateways';
+import { deleteClientGateway, getClientGateway, getClientGateways } from '../../../cloud/clientgateways';
 import { FiltersClientGateway, FiltersClientGatewayFromJSON } from 'outscale-api';
 
 export const CLIENTGATEWAYS_FOLDER_NAME = "Client Gateways";
@@ -26,7 +26,7 @@ export class ClientGatewaysFolderNode extends FiltersFolderNode<FiltersClientGat
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.clientGatewayId, "ClientGateway", deleteClientGateway));
+                resources.push(new ResourceNode(this.profile, "", item.clientGatewayId, "ClientGateway", deleteClientGateway, getClientGateway));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.dhcpoption.ts
+++ b/src/flat/folders/simple/node.folder.dhcpoption.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteDhcpOption, getDhcpOptions } from '../../../cloud/dhcpoptions';
+import { deleteDhcpOption, getDhcpOption, getDhcpOptions } from '../../../cloud/dhcpoptions';
 import { FiltersDhcpOptions, FiltersDhcpOptionsFromJSON } from 'outscale-api';
 
 export const DHCPOPTIONS_FOLDER_NAME = "Dhcp Options";
@@ -26,7 +26,7 @@ export class DhcpOptionsFolderNode extends FiltersFolderNode<FiltersDhcpOptions>
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.dhcpOptionsSetId, "DhcpOption", deleteDhcpOption));
+                resources.push(new ResourceNode(this.profile, "", item.dhcpOptionsSetId, "DhcpOption", deleteDhcpOption, getDhcpOption));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.directlink.ts
+++ b/src/flat/folders/simple/node.folder.directlink.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteDirectLink, getDirectLinks } from '../../../cloud/directlinks';
+import { deleteDirectLink, getDirectLink, getDirectLinks } from '../../../cloud/directlinks';
 import { FiltersDirectLink, FiltersDirectLinkFromJSON } from 'outscale-api';
 
 export const DIRECTLINKS_FOLDER_NAME = "DirectLinks";
@@ -26,7 +26,7 @@ export class DirectLinksFolderNode extends FiltersFolderNode<FiltersDirectLink> 
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.directLinkId, "DirectLink", deleteDirectLink));
+                resources.push(new ResourceNode(this.profile, "", item.directLinkId, "DirectLink", deleteDirectLink, getDirectLink));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.directlinkinterface.ts
+++ b/src/flat/folders/simple/node.folder.directlinkinterface.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteDirectLinkInterface, getDirectLinkInterfaces } from '../../../cloud/directlinkinterfaces';
+import { deleteDirectLinkInterface, getDirectLinkInterface, getDirectLinkInterfaces } from '../../../cloud/directlinkinterfaces';
 import { FiltersDirectLinkInterface, FiltersDirectLinkInterfaceFromJSON } from 'outscale-api';
 
 export const DIRECTLINKINTERFACES_FOLDER_NAME = "DirectLink Interfaces";
@@ -26,7 +26,7 @@ export class DirectLinkInterfacesFolderNode extends FiltersFolderNode<FiltersDir
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.directLinkInterfaceId, "DirectLinkInterface", deleteDirectLinkInterface));
+                resources.push(new ResourceNode(this.profile, "", item.directLinkInterfaceId, "DirectLinkInterface", deleteDirectLinkInterface, getDirectLinkInterface));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.image.ts
+++ b/src/flat/folders/simple/node.folder.image.ts
@@ -3,7 +3,7 @@ import * as osc from "outscale-api";
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FolderNode } from '../node.folder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteOMI, getOMIs } from '../../../cloud/images';
+import { deleteOMI, getOMI, getOMIs } from '../../../cloud/images';
 import { getAccounts } from '../../../cloud/account';
 
 export const IMAGES_FOLDER_NAME = "Images";
@@ -32,7 +32,7 @@ export class OMIsFolderNode extends FolderNode implements ExplorerFolderNode {
                     if (typeof image.imageId === 'undefined' || typeof image.imageName === 'undefined') {
                         continue;
                     }
-                    resources.push(new ResourceNode(this.profile, image.imageName, image.imageId, "omis", deleteOMI));
+                    resources.push(new ResourceNode(this.profile, image.imageName, image.imageId, "omis", deleteOMI, getOMI));
                 }
                 return Promise.resolve(resources.sort(resourceNodeCompare));
             });

--- a/src/flat/folders/simple/node.folder.keypair.ts
+++ b/src/flat/folders/simple/node.folder.keypair.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteKeypair, getKeypairs } from '../../../cloud/keypairs';
+import { deleteKeypair, getKeypair, getKeypairs } from '../../../cloud/keypairs';
 import { FiltersKeypair, FiltersKeypairFromJSON } from 'outscale-api';
 
 export const KEYPAIRS_FOLDER_NAME = "Keypairs";
@@ -23,7 +23,7 @@ export class KeypairsFolderNode extends FiltersFolderNode<FiltersKeypair> implem
                 if (typeof keypair.keypairName === 'undefined') {
                     continue;
                 }
-                resources.push(new ResourceNode(this.profile, "", keypair.keypairName, "keypairs", deleteKeypair));
+                resources.push(new ResourceNode(this.profile, "", keypair.keypairName, "keypairs", deleteKeypair, getKeypair));
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));
         });

--- a/src/flat/folders/simple/node.folder.loadbalancer.ts
+++ b/src/flat/folders/simple/node.folder.loadbalancer.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { deleteLoadBalancer, getLoadBalancers } from '../../../cloud/loadbalancers';
+import { deleteLoadBalancer, getLoadBalancer, getLoadBalancers } from '../../../cloud/loadbalancers';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
@@ -23,7 +23,7 @@ export class LoadBalancerFolderNode extends FiltersFolderNode<FiltersLoadBalance
                 if (typeof lb.loadBalancerName === 'undefined') {
                     continue;
                 }
-                resources.push(new ResourceNode(this.profile, "", lb.loadBalancerName, "loadbalancers", deleteLoadBalancer));
+                resources.push(new ResourceNode(this.profile, "", lb.loadBalancerName, "loadbalancers", deleteLoadBalancer, getLoadBalancer));
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));
         });

--- a/src/flat/folders/simple/node.folder.natservice.ts
+++ b/src/flat/folders/simple/node.folder.natservice.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteNatService, getNatServices } from '../../../cloud/natservices';
+import { deleteNatService, getNatService, getNatServices } from '../../../cloud/natservices';
 import { FiltersNatService, FiltersNatServiceFromJSON } from 'outscale-api';
 
 export const NATSERVICES_FOLDER_NAME = "Nat Services";
@@ -26,7 +26,7 @@ export class NatServicesFolderNode extends FiltersFolderNode<FiltersNatService> 
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.natServiceId, "NatService", deleteNatService));
+                resources.push(new ResourceNode(this.profile, "", item.natServiceId, "NatService", deleteNatService, getNatService));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.netaccesspoint.ts
+++ b/src/flat/folders/simple/node.folder.netaccesspoint.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteNetAccessPoint, getNetAccessPoints } from '../../../cloud/netaccesspoints';
+import { deleteNetAccessPoint, getNetAccessPoint, getNetAccessPoints } from '../../../cloud/netaccesspoints';
 import { FiltersNetAccessPoint, FiltersNetAccessPointFromJSON } from 'outscale-api';
 
 export const NETACCESSPOINTS_FOLDER_NAME = "Net AccessPoints";
@@ -26,7 +26,7 @@ export class NetAccessPointsFolderNode extends FiltersFolderNode<FiltersNetAcces
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.netAccessPointId, "NetAccessPoint", deleteNetAccessPoint));
+                resources.push(new ResourceNode(this.profile, "", item.netAccessPointId, "NetAccessPoint", deleteNetAccessPoint, getNetAccessPoint));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.netpeering.ts
+++ b/src/flat/folders/simple/node.folder.netpeering.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteNetPeering, getNetPeerings } from '../../../cloud/netpeerings';
+import { deleteNetPeering, getNetPeering, getNetPeerings } from '../../../cloud/netpeerings';
 import { FiltersNetPeering, FiltersNetPeeringFromJSON } from 'outscale-api';
 
 export const NETPEERINGS_FOLDER_NAME = "Net Peerings";
@@ -26,7 +26,7 @@ export class NetPeeringsFolderNode extends FiltersFolderNode<FiltersNetPeering> 
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.netPeeringId, "NetPeering", deleteNetPeering));
+                resources.push(new ResourceNode(this.profile, "", item.netPeeringId, "NetPeering", deleteNetPeering, getNetPeering));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.snapshot.ts
+++ b/src/flat/folders/simple/node.folder.snapshot.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteSnapshot, getSnapshots } from '../../../cloud/snapshots';
+import { deleteSnapshot, getSnapshot, getSnapshots } from '../../../cloud/snapshots';
 import { FiltersSnapshot, FiltersSnapshotFromJSON } from 'outscale-api';
 
 export const SNAPSHOTS_FOLDER_NAME = "Snapshots";
@@ -23,7 +23,7 @@ export class SnapshotsFolderNode extends FiltersFolderNode<FiltersSnapshot> impl
                 if (typeof snapshot.snapshotId === 'undefined' || typeof snapshot.description === 'undefined') {
                     continue;
                 }
-                resources.push(new ResourceNode(this.profile, snapshot.description, snapshot.snapshotId, "snapshots", deleteSnapshot));
+                resources.push(new ResourceNode(this.profile, snapshot.description, snapshot.snapshotId, "snapshots", deleteSnapshot, getSnapshot));
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));
         });

--- a/src/flat/folders/simple/node.folder.subnet.ts
+++ b/src/flat/folders/simple/node.folder.subnet.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteSubnet, getSubnets } from '../../../cloud/subnets';
+import { deleteSubnet, getSubnet, getSubnets } from '../../../cloud/subnets';
 import { FiltersSubnet, FiltersSubnetFromJSON } from 'outscale-api';
 
 export const SUBNETS_FOLDER_NAME = "Subnets";
@@ -26,7 +26,7 @@ export class SubnetsFolderNode extends FiltersFolderNode<FiltersSubnet> implemen
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.subnetId, "Subnet", deleteSubnet));
+                resources.push(new ResourceNode(this.profile, "", item.subnetId, "Subnet", deleteSubnet, getSubnet));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/simple/node.folder.vpnconnection.ts
+++ b/src/flat/folders/simple/node.folder.vpnconnection.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
 import { ResourceNode } from '../../resources/node.resources';
-import { deleteVpnConnection, getVpnConnections } from '../../../cloud/vpnconnections';
+import { deleteVpnConnection, getVpnConnection, getVpnConnections } from '../../../cloud/vpnconnections';
 import { FiltersVpnConnection, FiltersVpnConnectionFromJSON } from 'outscale-api';
 
 export const VPNCONNECTIONS_FOLDER_NAME = "Vpn Connections";
@@ -26,7 +26,7 @@ export class VpnConnectionsFolderNode extends FiltersFolderNode<FiltersVpnConnec
                     continue;
                 }
 
-                resources.push(new ResourceNode(this.profile, "", item.vpnConnectionId, "VpnConnection", deleteVpnConnection));
+                resources.push(new ResourceNode(this.profile, "", item.vpnConnectionId, "VpnConnection", deleteVpnConnection, getVpnConnection));
 
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));

--- a/src/flat/folders/specific/node.folder.net.ts
+++ b/src/flat/folders/specific/node.folder.net.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerFolderNode, Profile, resourceNodeCompare } from '../../node';
 import { FiltersFolderNode } from '../node.filterfolder';
-import { ResourceNode } from '../../resources/node.resources';
-import { deleteNet, getNets } from '../../../cloud/nets';
+import { getNets } from '../../../cloud/nets';
 import { FiltersNet, FiltersNetFromJSON } from 'outscale-api';
+import { NetResourceNode } from '../../resources/node.resources.nets';
 
 export const NET_FOLDER_NAME = "Nets";
 export class VpcFolderNode extends FiltersFolderNode<FiltersNet> implements ExplorerFolderNode {
@@ -23,7 +23,7 @@ export class VpcFolderNode extends FiltersFolderNode<FiltersNet> implements Expl
                 if (typeof net.netId === 'undefined') {
                     continue;
                 }
-                resources.push(new ResourceNode(this.profile, "", net.netId?.toString(), "vpc", deleteNet));
+                resources.push(new NetResourceNode(this.profile, "", net.netId?.toString()));
             }
             return Promise.resolve(resources.sort(resourceNodeCompare));
         });

--- a/src/flat/node.profile.ts
+++ b/src/flat/node.profile.ts
@@ -101,8 +101,7 @@ export class ProfileNode implements ExplorerProfileNode {
             return this.profile.accountId;
         }
         const res = await getAccount(this.profile, "");
-        if (typeof res === "string") {
-            vscode.window.showErrorMessage(vscode.l10n.t(`Error while reading {0}: {1}`, "Account", res));
+        if (typeof res === "string" || typeof res === 'undefined') {
             return Promise.resolve(undefined);
         }
 

--- a/src/flat/node.profile.ts
+++ b/src/flat/node.profile.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ExplorerNode, ExplorerProfileNode, Profile } from './node';
 import { VmsFolderNode, VM_FOLDER_NAME } from './folders/specific/node.folder.vm';
-import { NET_FOLDER_NAME, VpcFolderNode } from './folders/simple/node.folder.net';
+import { NET_FOLDER_NAME, VpcFolderNode } from './folders/specific/node.folder.net';
 import { SecurityGroupsFolderNode, SECURITYGROUPS_FOLDER_NAME } from './folders/specific/node.folder.securitygroup';
 import { KeypairsFolderNode, KEYPAIRS_FOLDER_NAME } from './folders/simple/node.folder.keypair';
 import { VolumeFolderNode, VOLUME_FOLDER_NAME } from './folders/specific/node.folder.volume';

--- a/src/flat/resources/node.resources.eip.ts
+++ b/src/flat/resources/node.resources.eip.ts
@@ -25,7 +25,16 @@ export class PublicIpResourceNode extends ResourceNode implements LinkResourceNo
 
     }
 
-    unlinkResource(): Promise<string | undefined> {
+    async unlinkResource(): Promise<string | undefined> {
+        const ip = await getExternalIP(this.profile, this.resourceId);
+        if (typeof ip === "string" || typeof ip === "undefined") {
+            return ip;
+        }
+
+        if (typeof ip.linkPublicIpId === "undefined") {
+            return undefined;
+        }
+
         return unlinkExternalIP(this.profile, this.resourceName);
     }
 

--- a/src/flat/resources/node.resources.eip.ts
+++ b/src/flat/resources/node.resources.eip.ts
@@ -29,4 +29,9 @@ export class PublicIpResourceNode extends ResourceNode implements LinkResourceNo
         return unlinkExternalIP(this.profile, this.resourceName);
     }
 
+    unlinkAllResource(): Promise<string | undefined> {
+        // One link possible
+        return this.unlinkResource();
+    }
+
 }

--- a/src/flat/resources/node.resources.eip.ts
+++ b/src/flat/resources/node.resources.eip.ts
@@ -25,6 +25,15 @@ export class PublicIpResourceNode extends ResourceNode implements LinkResourceNo
 
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        const res = await this.unlinkAllResource();
+        if (typeof res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
     async unlinkResource(): Promise<string | undefined> {
         const ip = await getExternalIP(this.profile, this.resourceId);
         if (typeof ip === "string" || typeof ip === "undefined") {

--- a/src/flat/resources/node.resources.eip.ts
+++ b/src/flat/resources/node.resources.eip.ts
@@ -1,5 +1,5 @@
 import { ThemeIcon } from 'vscode';
-import { deleteExternalIP, unlinkExternalIP } from '../../cloud/publicips';
+import { deleteExternalIP, unlinkExternalIP, getExternalIP } from '../../cloud/publicips';
 import { Profile } from '../node';
 import { ResourceNode } from './node.resources';
 import { LinkResourceNode } from './types/node.resources.link';
@@ -8,7 +8,7 @@ import { LinkResourceNode } from './types/node.resources.link';
 export class PublicIpResourceNode extends ResourceNode implements LinkResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceState: string) {
-        super(profile, resourceName, resourceId, "eips", deleteExternalIP);
+        super(profile, resourceName, resourceId, "eips", deleteExternalIP, getExternalIP);
     }
 
     getContextValue(): string {

--- a/src/flat/resources/node.resources.flexiblegpus.ts
+++ b/src/flat/resources/node.resources.flexiblegpus.ts
@@ -30,7 +30,16 @@ export class FlexibleGpuResourceNode extends ResourceNode implements LinkResourc
 
     }
 
-    unlinkResource(): Promise<string | undefined> {
+    async unlinkResource(): Promise<string | undefined> {
+        const fgpu = await getFlexibleGpu(this.profile, this.resourceId);
+        if (typeof fgpu === 'string' || typeof fgpu === "undefined") {
+            return fgpu;
+        }
+
+        if (typeof fgpu.vmId === 'undefined') {
+            return undefined;
+        }
+
         return unlinkFlexibleGpu(this.profile, this.resourceId);
     }
 

--- a/src/flat/resources/node.resources.flexiblegpus.ts
+++ b/src/flat/resources/node.resources.flexiblegpus.ts
@@ -1,5 +1,5 @@
 import { ThemeIcon } from 'vscode';
-import { deleteFlexibleGpu, unlinkFlexibleGpu } from '../../cloud/flexiblegpus';
+import { deleteFlexibleGpu, getFlexibleGpu, unlinkFlexibleGpu } from '../../cloud/flexiblegpus';
 import { Profile } from '../node';
 import { ResourceNode } from './node.resources';
 import { LinkResourceNode } from './types/node.resources.link';
@@ -8,7 +8,7 @@ import { LinkResourceNode } from './types/node.resources.link';
 export class FlexibleGpuResourceNode extends ResourceNode implements LinkResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceState: string) {
-        super(profile, resourceName, resourceId, "FlexibleGpu", deleteFlexibleGpu);
+        super(profile, resourceName, resourceId, "FlexibleGpu", deleteFlexibleGpu, getFlexibleGpu);
     }
 
     getContextValue(): string {

--- a/src/flat/resources/node.resources.flexiblegpus.ts
+++ b/src/flat/resources/node.resources.flexiblegpus.ts
@@ -30,6 +30,15 @@ export class FlexibleGpuResourceNode extends ResourceNode implements LinkResourc
 
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        const res = await this.unlinkAllResource();
+        if (res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
     async unlinkResource(): Promise<string | undefined> {
         const fgpu = await getFlexibleGpu(this.profile, this.resourceId);
         if (typeof fgpu === 'string' || typeof fgpu === "undefined") {

--- a/src/flat/resources/node.resources.flexiblegpus.ts
+++ b/src/flat/resources/node.resources.flexiblegpus.ts
@@ -34,4 +34,8 @@ export class FlexibleGpuResourceNode extends ResourceNode implements LinkResourc
         return unlinkFlexibleGpu(this.profile, this.resourceId);
     }
 
+    unlinkAllResource(): Promise<string | undefined> {
+        return this.unlinkResource();
+    }
+
 }

--- a/src/flat/resources/node.resources.internetservices.ts
+++ b/src/flat/resources/node.resources.internetservices.ts
@@ -8,7 +8,7 @@ import { LinkResourceNode } from './types/node.resources.link';
 export class InternetServiceResourceNode extends ResourceNode implements LinkResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceState: string) {
-        super(profile, resourceName, resourceId, "InternetService", deleteInternetService);
+        super(profile, resourceName, resourceId, "InternetService", deleteInternetService, getInternetService);
     }
 
     getContextValue(): string {
@@ -27,7 +27,7 @@ export class InternetServiceResourceNode extends ResourceNode implements LinkRes
 
     async unlinkResource(): Promise<string | undefined> {
         const internetService = await getInternetService(this.profile, this.resourceId);
-        if (typeof internetService === "string") {
+        if (typeof internetService === "string" || typeof internetService === 'undefined') {
             return internetService;
         }
 

--- a/src/flat/resources/node.resources.internetservices.ts
+++ b/src/flat/resources/node.resources.internetservices.ts
@@ -25,6 +25,15 @@ export class InternetServiceResourceNode extends ResourceNode implements LinkRes
 
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        const res = await this.unlinkAllResource();
+        if (res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
     async unlinkResource(): Promise<string | undefined> {
         const internetService = await getInternetService(this.profile, this.resourceId);
         if (typeof internetService === "string" || typeof internetService === 'undefined') {

--- a/src/flat/resources/node.resources.internetservices.ts
+++ b/src/flat/resources/node.resources.internetservices.ts
@@ -32,7 +32,7 @@ export class InternetServiceResourceNode extends ResourceNode implements LinkRes
         }
 
         if (typeof internetService.netId === "undefined") {
-            return Promise.resolve(vscode.l10n.t("The resource is not linked"));
+            return undefined;
         }
 
 

--- a/src/flat/resources/node.resources.internetservices.ts
+++ b/src/flat/resources/node.resources.internetservices.ts
@@ -39,4 +39,8 @@ export class InternetServiceResourceNode extends ResourceNode implements LinkRes
         return unlinkInternetService(this.profile, this.resourceId, internetService.netId);
     }
 
+    unlinkAllResource(): Promise<string | undefined> {
+        return this.unlinkResource();
+    }
+
 }

--- a/src/flat/resources/node.resources.nets.ts
+++ b/src/flat/resources/node.resources.nets.ts
@@ -1,0 +1,15 @@
+import { deleteNet, getNet } from "../../cloud/nets";
+import { Profile } from '../node';
+import { ResourceNode } from './node.resources';
+export class NetResourceNode extends ResourceNode {
+
+    constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string) {
+        super(profile, resourceName, resourceId, "vpc", deleteNet, getNet);
+    }
+
+    getContextValue(): string {
+        return "netresourcenode";
+    }
+
+
+}

--- a/src/flat/resources/node.resources.nets.ts
+++ b/src/flat/resources/node.resources.nets.ts
@@ -1,6 +1,29 @@
+import * as vscode from 'vscode';
+import { getInternetServices } from "../../cloud/internetservices";
+import { deleteLoadBalancer, getLoadBalancer, getLoadBalancersInNet } from "../../cloud/loadbalancers";
+import { deleteNatService, getNatService, getNatServices } from "../../cloud/natservices";
+import { deleteNetAccessPoint, getNetAccessPoint, getNetAccessPoints } from "../../cloud/netaccesspoints";
+import { deleteNetPeering, getNetPeering, getNetPeerings } from '../../cloud/netpeerings';
 import { deleteNet, getNet } from "../../cloud/nets";
+import { getNics } from "../../cloud/nics";
+import { deleteExternalIP, getExternalIP } from '../../cloud/publicips';
+import { getRouteTables } from "../../cloud/routetables";
+import { getSecurityGroups } from "../../cloud/securitygroups";
+import { deleteSubnet, getSubnet, getSubnets } from "../../cloud/subnets";
+import { getVirtualGateways } from "../../cloud/virtualgateways";
+import { getVmsInNet } from "../../cloud/vms";
+import { deleteVpnConnection, getVpnConnection, getVpnConnections } from "../../cloud/vpnconnections";
+import { OutputChannel } from '../../logs/output_channel';
 import { Profile } from '../node';
 import { ResourceNode } from './node.resources';
+import { InternetServiceResourceNode } from "./node.resources.internetservices";
+import { NicResourceNode } from "./node.resources.nics";
+import { RouteTableResourceNode } from "./node.resources.routetables";
+import { SecurityGroupResourceNode } from "./node.resources.securitygroups";
+import { VirtualGatewayResourceNode } from "./node.resources.virtualgateways";
+import { VmResourceNode } from "./node.resources.vms";
+
+
 export class NetResourceNode extends ResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string) {
@@ -10,6 +33,267 @@ export class NetResourceNode extends ResourceNode {
     getContextValue(): string {
         return "netresourcenode";
     }
+
+    async teardown(): Promise<string | undefined> {
+        let resourceToDelete: (ResourceNode | undefined)[] = [];
+        const outputChannel = OutputChannel.getInstance();
+
+        // VMs
+        const vms = await getVmsInNet(this.profile, this.resourceId);
+        if (typeof vms === "string") {
+            outputChannel.appendLine(vms);
+        } else {
+            const res = vms.map((vm) => {
+                if (typeof vm.vmId === 'undefined') {
+                    return undefined;
+                }
+                return new VmResourceNode(this.profile, "", vm.vmId, "");
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // LBUs
+        const lbus = await getLoadBalancersInNet(this.profile, this.resourceId);
+        if (typeof lbus === "string") {
+            outputChannel.appendLine(lbus);
+        } else {
+            const res = lbus.map((lbu) => {
+                if (typeof lbu.loadBalancerName === 'undefined') {
+                    return undefined;
+                }
+                return new ResourceNode(this.profile, "", lbu.loadBalancerName, "loadbalancers", deleteLoadBalancer, getLoadBalancer);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Net peering (check all source and target)
+        // Sources
+        let netPeers = await getNetPeerings(this.profile, { sourceNetNetIds: [this.resourceId] });
+        if (typeof netPeers === 'string') {
+            outputChannel.appendLine(netPeers);
+        } else {
+            const res = netPeers.map((netPeer) => {
+                if (typeof netPeer.netPeeringId === 'undefined') {
+                    return undefined;
+                }
+                return new ResourceNode(this.profile, "", netPeer.netPeeringId, "NetPeering", deleteNetPeering, getNetPeering);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        netPeers = await getNetPeerings(this.profile, { accepterNetNetIds: [this.resourceId] });
+        if (typeof netPeers === 'string') {
+            outputChannel.appendLine(netPeers);
+        } else {
+            const res = netPeers.map((netPeer) => {
+                if (typeof netPeer.netPeeringId === 'undefined') {
+                    return undefined;
+                }
+                return new ResourceNode(this.profile, "", netPeer.netPeeringId, "NetPeering", deleteNetPeering, getNetPeering);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Public IP
+        // Retrieve all the links ?
+        const publicIpIds: string[] = [];
+
+        // Net Access Point
+        const naps = await getNetAccessPoints(this.profile, { netIds: [this.resourceId] });
+        if (typeof naps === "string") {
+            outputChannel.appendLine(naps);
+        } else {
+            const res = naps.map((nap) => {
+                if (typeof nap.netAccessPointId === 'undefined') {
+                    return undefined;
+                }
+
+                return new ResourceNode(this.profile, "", nap.netAccessPointId, "NetAccessPoint", deleteNetAccessPoint, getNetAccessPoint);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Routes (Deletion with route table)
+
+        // Nat Services
+        const nats = await getNatServices(this.profile, { netIds: [this.resourceId] });
+        if (typeof nats === "string") {
+            outputChannel.appendLine(nats);
+        } else {
+            const res = nats.map((nat) => {
+                if (typeof nat.natServiceId === 'undefined') {
+                    return undefined;
+                }
+
+                if (typeof nat.publicIps !== 'undefined') {
+                    for (const publicIp of nat.publicIps) {
+                        if (typeof publicIp.publicIpId === 'undefined') {
+                            continue;
+                        }
+                        publicIpIds.push(publicIp.publicIpId);
+                    }
+                }
+
+                return new ResourceNode(this.profile, "", nat.natServiceId, "NatService", deleteNatService, getNatService);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Routes Tables
+        const rts = await getRouteTables(this.profile, { netIds: [this.resourceId] });
+        if (typeof rts === "string") {
+            outputChannel.appendLine(rts);
+        } else {
+            const res = rts.map((rt) => {
+                if (typeof rt.routeTableId === 'undefined') {
+                    return undefined;
+                }
+
+                return new RouteTableResourceNode(this.profile, "", rt.routeTableId, "");
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Security groups Rules (delete with Security Groups)
+
+        // Security group
+        const sgs = await getSecurityGroups(this.profile, { netIds: [this.resourceId] });
+        if (typeof sgs === "string") {
+            outputChannel.appendLine(sgs);
+        } else {
+            const res = sgs.map((sg) => {
+                if (typeof sg.securityGroupId === 'undefined') {
+                    return undefined;
+                }
+                return new SecurityGroupResourceNode(this.profile, "", sg.securityGroupId);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Virtual Gateways
+        const vgs = await getVirtualGateways(this.profile, { linkNetIds: [this.resourceId] });
+        const vgsIds: string[] = [];
+        if (typeof vgs === "string") {
+            outputChannel.appendLine(vgs);
+        } else {
+            const res = vgs.map((vg) => {
+                if (typeof vg.virtualGatewayId === 'undefined') {
+                    return undefined;
+                }
+                vgsIds.push(vg.virtualGatewayId);
+                return new VirtualGatewayResourceNode(this.profile, "", vg.virtualGatewayId);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Nics
+        const nics = await getNics(this.profile, { netIds: [this.resourceId] });
+        if (typeof nics === "string") {
+            outputChannel.appendLine(nics);
+        } else {
+            const res = nics.map((nic) => {
+                if (typeof nic.nicId === 'undefined') {
+                    return undefined;
+                }
+
+                if (typeof nic.linkPublicIp !== 'undefined' && typeof nic.linkPublicIp.publicIpId !== 'undefined') {
+                    publicIpIds.push(nic.linkPublicIp.publicIpId);
+                }
+
+                return new NicResourceNode(this.profile, "", nic.nicId, "");
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Subnets
+        const subnets = await getSubnets(this.profile, { netIds: [this.resourceId] });
+        if (typeof subnets === "string") {
+            outputChannel.appendLine(subnets);
+        } else {
+            const res = subnets.map((subnet) => {
+                if (typeof subnet.subnetId === 'undefined') {
+                    return undefined;
+                }
+
+                return new ResourceNode(this.profile, "", subnet.subnetId, "Subnet", deleteSubnet, getSubnet);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // Internet Services
+        const iss = await getInternetServices(this.profile, { linkNetIds: [this.resourceId] });
+        if (typeof iss === "string") {
+            outputChannel.appendLine(iss);
+        } else {
+            const res = iss.map((is) => {
+                if (typeof is.internetServiceId === 'undefined') {
+                    return undefined;
+                }
+
+                return new InternetServiceResourceNode(this.profile, "", is.internetServiceId, "");
+            });
+            resourceToDelete.push(...res);
+        }
+
+        // VPN Connections (Virtualgateway ou client gateway)
+        const vpns = await getVpnConnections(this.profile, { virtualGatewayIds: vgsIds });
+        if (typeof vpns === "string") {
+            outputChannel.appendLine(vpns);
+        } else {
+            const res = vpns.map((vpn) => {
+                if (typeof vpn.vpnConnectionId === 'undefined') {
+                    return undefined;
+                }
+
+                return new ResourceNode(this.profile, "", vpn.vpnConnectionId, "VpnConnection", deleteVpnConnection, getVpnConnection);
+            });
+            resourceToDelete.push(...res);
+        }
+
+        //PublicIP
+        const ips = publicIpIds.map((ip) => new ResourceNode(this.profile, "", ip, "eips", deleteExternalIP, getExternalIP));
+        resourceToDelete.push(...ips);
+
+        // Net
+        resourceToDelete.push(this);
+
+        const res = await vscode.window.withProgress({ title: vscode.l10n.t("Teardown Net '{0}'", this.resourceId), location: vscode.ProgressLocation.Notification, cancellable: true }, async (p, token) => {
+            while (resourceToDelete.length !== 0) {
+                p.report({ message: vscode.l10n.t("{0} resources to clean...", resourceToDelete.length) });
+                const nextRoundToDelete = [];
+                for (const resource of resourceToDelete) {
+                    if (token.isCancellationRequested) {
+                        return vscode.l10n.t("Cancelled by the user");
+                    }
+
+                    if (typeof resource === 'undefined') {
+                        continue;
+                    }
+                    p.report({
+                        message: vscode.l10n.t("Cleaning {0}...", resource.resourceId)
+                    });
+                    const res = await resource.deleteResource();
+                    if (typeof res === 'string') {
+                        // Check that the resource is still present
+                        p.report({ message: vscode.l10n.t("Error while cleaning {0}: {1}", resource.resourceId, res) });
+                        nextRoundToDelete.push(resource);
+                    } else {
+                        p.report({ message: vscode.l10n.t("Succeed to clean {0}", resource.resourceId) });
+                    }
+                }
+                resourceToDelete = nextRoundToDelete;
+                if (resourceToDelete.length > 0) {
+                    p.report({ message: vscode.l10n.t("{0} resources to clean...", resourceToDelete.length) });
+                    await new Promise(f => setTimeout(f, 5000));
+                }
+            }
+            return undefined;
+        });
+
+        return Promise.resolve(res);
+    }
+
+
 
 
 }

--- a/src/flat/resources/node.resources.nics.ts
+++ b/src/flat/resources/node.resources.nics.ts
@@ -38,7 +38,7 @@ export class NicResourceNode extends ResourceNode implements LinkResourceNode {
         }
 
         if (typeof nic.linkNic === "undefined") {
-            return Promise.resolve(vscode.l10n.t("The resource is not linked"));
+            return undefined;
         }
 
         const link = nic.linkNic;

--- a/src/flat/resources/node.resources.nics.ts
+++ b/src/flat/resources/node.resources.nics.ts
@@ -31,6 +31,15 @@ export class NicResourceNode extends ResourceNode implements LinkResourceNode {
 
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        const res = await this.unlinkAllResource();
+        if (res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
     async unlinkResource(): Promise<string | undefined> {
         const nic = await getNic(this.profile, this.resourceId);
         if (typeof nic === "string" || typeof nic === "undefined") {

--- a/src/flat/resources/node.resources.nics.ts
+++ b/src/flat/resources/node.resources.nics.ts
@@ -50,4 +50,9 @@ export class NicResourceNode extends ResourceNode implements LinkResourceNode {
         return unlinkNic(this.profile, link.linkNicId);
     }
 
+    unlinkAllResource(): Promise<string | undefined> {
+        // Only one link possible
+        return this.unlinkResource();
+    }
+
 }

--- a/src/flat/resources/node.resources.nics.ts
+++ b/src/flat/resources/node.resources.nics.ts
@@ -8,7 +8,7 @@ import { LinkResourceNode } from './types/node.resources.link';
 export class NicResourceNode extends ResourceNode implements LinkResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceState: string) {
-        super(profile, resourceName, resourceId, "Nic", deleteNic);
+        super(profile, resourceName, resourceId, "Nic", deleteNic, getNic);
     }
 
     getContextValue(): string {
@@ -33,7 +33,7 @@ export class NicResourceNode extends ResourceNode implements LinkResourceNode {
 
     async unlinkResource(): Promise<string | undefined> {
         const nic = await getNic(this.profile, this.resourceId);
-        if (typeof nic === "string") {
+        if (typeof nic === "string" || typeof nic === "undefined") {
             return nic;
         }
 

--- a/src/flat/resources/node.resources.routetables.ts
+++ b/src/flat/resources/node.resources.routetables.ts
@@ -10,7 +10,7 @@ import { SubResourceNode } from "./types/node.resources.subresource";
 export class RouteTableResourceNode extends ResourceNode implements LinkResourceNode, SubResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceState: string) {
-        super(profile, resourceName, resourceId, "routetables", deleteRouteTable);
+        super(profile, resourceName, resourceId, "routetables", deleteRouteTable, getRouteTable);
     }
 
     getContextValue(): string {
@@ -29,7 +29,7 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
 
     async unlinkResource(): Promise<string | undefined> {
         const rt = await getRouteTable(this.profile, this.resourceId);
-        if (typeof rt === "string") {
+        if (typeof rt === "string" || typeof rt === 'undefined') {
             return rt;
         }
 
@@ -66,7 +66,7 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
 
     async removeSubresource(): Promise<string | undefined> {
         const rt = await getRouteTable(this.profile, this.resourceId);
-        if (typeof rt === "string") {
+        if (typeof rt === "string" || typeof rt === 'undefined') {
             return rt;
         }
 

--- a/src/flat/resources/node.resources.routetables.ts
+++ b/src/flat/resources/node.resources.routetables.ts
@@ -101,6 +101,29 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
         return removeRoute(this.profile, this.resourceId, route.destinationIpRange);
     }
 
+    async removeAllSubresources(): Promise<string | undefined> {
+        const rt = await getRouteTable(this.profile, this.resourceId);
+        if (typeof rt === "string" || typeof rt === 'undefined') {
+            return rt;
+        }
+
+        if (typeof rt.routes === "undefined" || rt.routes.length === 0) {
+            return Promise.resolve(vscode.l10n.t("The resource has no subresources"));
+        }
+
+        for (const route of rt.routes) {
+            if (typeof route.destinationIpRange === "undefined") {
+                return Promise.resolve(vscode.l10n.t("The subresource is incomplete"));
+            }
+            const res = await removeRoute(this.profile, this.resourceId, route.destinationIpRange);
+            if (typeof res === 'string') {
+                return res;
+            }
+        }
+
+        return Promise.resolve(undefined);
+    }
+
     async unlinkAllResource(): Promise<string | undefined> {
         const rt = await getRouteTable(this.profile, this.resourceId);
         if (typeof rt === "string" || typeof rt === 'undefined') {

--- a/src/flat/resources/node.resources.routetables.ts
+++ b/src/flat/resources/node.resources.routetables.ts
@@ -100,4 +100,24 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
 
         return removeRoute(this.profile, this.resourceId, route.destinationIpRange);
     }
+
+    async unlinkAllResource(): Promise<string | undefined> {
+        const rt = await getRouteTable(this.profile, this.resourceId);
+        if (typeof rt === "string" || typeof rt === 'undefined') {
+            return rt;
+        }
+
+        if (typeof rt.linkRouteTables === "undefined" || rt.linkRouteTables.length === 0) {
+            return undefined;
+        }
+
+        for (const link of rt.linkRouteTables) {
+            if (typeof link.linkRouteTableId === "undefined") {
+                return Promise.resolve(vscode.l10n.t("The link is incomplete"));
+            }
+
+            return unlinkRouteTable(this.profile, link.linkRouteTableId);
+        }
+    }
+
 }

--- a/src/flat/resources/node.resources.routetables.ts
+++ b/src/flat/resources/node.resources.routetables.ts
@@ -27,6 +27,20 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
 
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        let res = await this.unlinkAllResource();
+        if (res === 'string') {
+            return res;
+        }
+
+        res = await this.removeAllSubresources();
+        if (res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
     async unlinkResource(): Promise<string | undefined> {
         const rt = await getRouteTable(this.profile, this.resourceId);
         if (typeof rt === "string" || typeof rt === 'undefined') {

--- a/src/flat/resources/node.resources.routetables.ts
+++ b/src/flat/resources/node.resources.routetables.ts
@@ -85,7 +85,7 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
         }
 
         if (typeof rt.routes === "undefined" || rt.routes.length === 0) {
-            return Promise.resolve(vscode.l10n.t("The resource has no subresources"));
+            return undefined;
         }
 
         let route: osc.Route;

--- a/src/flat/resources/node.resources.securitygroups.ts
+++ b/src/flat/resources/node.resources.securitygroups.ts
@@ -9,7 +9,7 @@ import { SubResourceNode } from "./types/node.resources.subresource";
 export class SecurityGroupResourceNode extends ResourceNode implements SubResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string) {
-        super(profile, resourceName, resourceId, "securitygroups", deleteSecurityGroup);
+        super(profile, resourceName, resourceId, "securitygroups", deleteSecurityGroup, getSecurityGroup);
     }
 
     getContextValue(): string {
@@ -18,7 +18,7 @@ export class SecurityGroupResourceNode extends ResourceNode implements SubResour
 
     async removeSubresource(): Promise<string | undefined> {
         const sg = await getSecurityGroup(this.profile, this.resourceId);
-        if (typeof sg === "string") {
+        if (typeof sg === "string" || typeof sg === 'undefined') {
             return sg;
         }
 

--- a/src/flat/resources/node.resources.securitygroups.ts
+++ b/src/flat/resources/node.resources.securitygroups.ts
@@ -16,6 +16,15 @@ export class SecurityGroupResourceNode extends ResourceNode implements SubResour
         return "securitygroupresourcenode;subresourcenode";
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        const res = await this.removeAllSubresources();
+        if (res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
     async removeSubresource(): Promise<string | undefined> {
         const sg = await getSecurityGroup(this.profile, this.resourceId);
         if (typeof sg === "string" || typeof sg === 'undefined') {

--- a/src/flat/resources/node.resources.securitygroups.ts
+++ b/src/flat/resources/node.resources.securitygroups.ts
@@ -81,6 +81,34 @@ export class SecurityGroupResourceNode extends ResourceNode implements SubResour
         return removeRule(this.profile, this.resourceId, flow, rule);
     }
 
+    async removeAllSubresources(): Promise<string | undefined> {
+        const sg = await getSecurityGroup(this.profile, this.resourceId);
+        if (typeof sg === "string" || typeof sg === 'undefined') {
+            return sg;
+        }
+
+        // Inbound
+        if (typeof sg.inboundRules !== 'undefined' && sg.inboundRules.length > 0) {
+            for (const rule of sg.inboundRules) {
+                const res = await removeRule(this.profile, this.resourceId, "Inbound", rule);
+                if (typeof res === 'string') {
+                    return res;
+                }
+            }
+        }
+
+        // Outbound
+        if (typeof sg.outboundRules !== 'undefined' && sg.outboundRules.length > 0) {
+            for (const rule of sg.outboundRules) {
+                const res = await removeRule(this.profile, this.resourceId, "Outbound", rule);
+                if (typeof res === 'string') {
+                    return res;
+                }
+            }
+        }
+
+        return Promise.resolve(undefined);
+    }
 
 
 }

--- a/src/flat/resources/node.resources.ts
+++ b/src/flat/resources/node.resources.ts
@@ -6,7 +6,7 @@ import { ExplorerNode, ExplorerResourceNode, Profile, ResourceNodeType } from '.
 export class ResourceNode implements ExplorerResourceNode {
 
 
-    constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceType: ResourceNodeType, readonly deleteFunc: (profile: Profile, resourceid: string) => Promise<string | undefined>) {
+    constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceType: ResourceNodeType, readonly deleteFunc: (profile: Profile, resourceid: string) => Promise<string | undefined>, readonly getFunc: (profile: Profile, resourceid: string) => Promise<any | string | undefined>) {
     }
 
     getResourceId(): Promise<string | undefined> {
@@ -21,7 +21,13 @@ export class ResourceNode implements ExplorerResourceNode {
         return "resourcenode";
     }
 
-    deleteResource(): Promise<string | undefined> {
+
+    async deleteResource(): Promise<string | undefined> {
+        const resource = await this.getFunc(this.profile, this.resourceId);
+        if (typeof resource === 'undefined' || typeof resource === 'string') {
+            return resource;
+        }
+
         return this.deleteFunc(this.profile, this.resourceId);
     }
 

--- a/src/flat/resources/node.resources.virtualgateways.ts
+++ b/src/flat/resources/node.resources.virtualgateways.ts
@@ -9,7 +9,7 @@ import { LinkResourceNode } from './types/node.resources.link';
 export class VirtualGatewayResourceNode extends ResourceNode implements LinkResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string) {
-        super(profile, resourceName, resourceId, "VirtualGateway", deleteVirtualGateway);
+        super(profile, resourceName, resourceId, "VirtualGateway", deleteVirtualGateway, getVirtualGateway);
     }
 
     getContextValue(): string {
@@ -19,7 +19,7 @@ export class VirtualGatewayResourceNode extends ResourceNode implements LinkReso
 
     async unlinkResource(): Promise<string | undefined> {
         const vgw = await getVirtualGateway(this.profile, this.resourceId);
-        if (typeof vgw === "string") {
+        if (typeof vgw === "string" || typeof vgw === 'undefined') {
             return vgw;
         }
 

--- a/src/flat/resources/node.resources.virtualgateways.ts
+++ b/src/flat/resources/node.resources.virtualgateways.ts
@@ -55,4 +55,27 @@ export class VirtualGatewayResourceNode extends ResourceNode implements LinkReso
 
     }
 
+    async unlinkAllResource(): Promise<string | undefined> {
+        const vgw = await getVirtualGateway(this.profile, this.resourceId);
+        if (typeof vgw === "string" || typeof vgw === 'undefined') {
+            return vgw;
+        }
+
+        if (typeof vgw.netToVirtualGatewayLinks === "undefined" || vgw.netToVirtualGatewayLinks.length === 0) {
+            return undefined;
+        }
+
+        for (const link of vgw.netToVirtualGatewayLinks) {
+            if (typeof link.netId === "undefined") {
+                return Promise.resolve(vscode.l10n.t("The link is incomplete"));
+            }
+            const res = await unlinkVirtualGateway(this.profile, this.resourceId, link.netId);
+            if (typeof res === 'string') {
+                return res;
+            }
+        }
+
+        return undefined;
+    }
+
 }

--- a/src/flat/resources/node.resources.virtualgateways.ts
+++ b/src/flat/resources/node.resources.virtualgateways.ts
@@ -16,6 +16,15 @@ export class VirtualGatewayResourceNode extends ResourceNode implements LinkReso
         return "virtualgatewayresourcenode;linkresourcenode";
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        const res = await this.unlinkAllResource();
+        if (res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
 
     async unlinkResource(): Promise<string | undefined> {
         const vgw = await getVirtualGateway(this.profile, this.resourceId);

--- a/src/flat/resources/node.resources.vms.ts
+++ b/src/flat/resources/node.resources.vms.ts
@@ -1,5 +1,5 @@
 import { ThemeIcon } from 'vscode';
-import { deleteVm, startVm, stopVm } from '../../cloud/vms';
+import { deleteVm, getVm, startVm, stopVm } from '../../cloud/vms';
 import { Profile } from '../node';
 import { ResourceNode } from './node.resources';
 
@@ -7,7 +7,7 @@ import { ResourceNode } from './node.resources';
 export class VmResourceNode extends ResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceState: string) {
-        super(profile, resourceName, resourceId, "vms", deleteVm);
+        super(profile, resourceName, resourceId, "vms", deleteVm, getVm);
     }
 
     startResource(): Promise<string | undefined> {

--- a/src/flat/resources/node.resources.volumes.ts
+++ b/src/flat/resources/node.resources.volumes.ts
@@ -35,7 +35,15 @@ export class VolumeResourceNode extends ResourceNode implements LinkResourceNode
 
     }
 
-    unlinkResource(): Promise<string | undefined> {
+    async unlinkResource(): Promise<string | undefined> {
+        const volume = await getVolume(this.profile, this.resourceId);
+        if (typeof volume === "string" || typeof volume === 'undefined') {
+            return volume;
+        }
+
+        if (typeof volume.linkedVolumes === "undefined" || volume.linkedVolumes.length === 0) {
+            return undefined;
+        }
         return unlinkVolume(this.profile, this.resourceId);
     }
 

--- a/src/flat/resources/node.resources.volumes.ts
+++ b/src/flat/resources/node.resources.volumes.ts
@@ -35,6 +35,15 @@ export class VolumeResourceNode extends ResourceNode implements LinkResourceNode
 
     }
 
+    async deleteResource(): Promise<string | undefined> {
+        const res = await this.unlinkAllResource();
+        if (res === 'string') {
+            return res;
+        }
+
+        return super.deleteResource();
+    }
+
     async unlinkResource(): Promise<string | undefined> {
         const volume = await getVolume(this.profile, this.resourceId);
         if (typeof volume === "string" || typeof volume === 'undefined') {

--- a/src/flat/resources/node.resources.volumes.ts
+++ b/src/flat/resources/node.resources.volumes.ts
@@ -39,4 +39,8 @@ export class VolumeResourceNode extends ResourceNode implements LinkResourceNode
         return unlinkVolume(this.profile, this.resourceId);
     }
 
+    unlinkAllResource(): Promise<string | undefined> {
+        return this.unlinkResource();
+    }
+
 }

--- a/src/flat/resources/node.resources.volumes.ts
+++ b/src/flat/resources/node.resources.volumes.ts
@@ -1,5 +1,5 @@
 import { ThemeIcon } from 'vscode';
-import { deleteVolume, unlinkVolume } from '../../cloud/volumes';
+import { deleteVolume, getVolume, unlinkVolume } from '../../cloud/volumes';
 import { Profile } from '../node';
 import { ResourceNode } from './node.resources';
 import { LinkResourceNode } from './types/node.resources.link';
@@ -8,7 +8,7 @@ import { LinkResourceNode } from './types/node.resources.link';
 export class VolumeResourceNode extends ResourceNode implements LinkResourceNode {
 
     constructor(readonly profile: Profile, readonly resourceName: string, readonly resourceId: string, readonly resourceState: string) {
-        super(profile, resourceName, resourceId, "volumes", deleteVolume);
+        super(profile, resourceName, resourceId, "volumes", deleteVolume, getVolume);
     }
 
     getContextValue(): string {

--- a/src/flat/resources/types/node.resources.link.ts
+++ b/src/flat/resources/types/node.resources.link.ts
@@ -2,4 +2,5 @@ import { ExplorerResourceNode } from "../../node";
 
 export interface LinkResourceNode extends ExplorerResourceNode {
     unlinkResource(): Promise<string | undefined>
+    unlinkAllResource(): Promise<string | undefined>
 }

--- a/src/flat/resources/types/node.resources.subresource.ts
+++ b/src/flat/resources/types/node.resources.subresource.ts
@@ -2,4 +2,5 @@ import { ExplorerResourceNode } from "../../node";
 
 export interface SubResourceNode extends ExplorerResourceNode {
     removeSubresource(): Promise<string | undefined>
+    removeAllSubresources(): Promise<string | undefined>
 }

--- a/src/logs/output_channel.ts
+++ b/src/logs/output_channel.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+
+
+export class OutputChannel {
+    private static instance: vscode.OutputChannel;
+
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() { }
+
+
+    public static getInstance(): vscode.OutputChannel {
+        if (!OutputChannel.instance) {
+            OutputChannel.instance = vscode.window.createOutputChannel("osc-viewer");
+            OutputChannel.instance.show();
+        }
+
+        return OutputChannel.instance;
+    }
+
+}


### PR DESCRIPTION
This PR is to add help user destroy a Net (like cockpit teardown).

A lot of changes has been made:
- Idempotence during deletion and unlink
- check existance of resource before removing it
- creation of a centralized output ([Outputchannel](https://code.visualstudio.com/api/references/vscode-api#OutputChannel)) for all the logs

For the teardown, here are the resources deleted:
- VM
- Load Balancer
- Net Peering
- Public IP
- Net Access Point
- NAt Service
- Route Table
- Security Group
- Virtual Gateway
- NIC
- Subnet
- Internet Service
- VPN Connection