### PR TITLE
Fix Net graph with VGW links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [v0.6.1]
+### Bugfixes
+  - Add Virtual Private Gateway to the Net visualization graph 
 ## [v0.6.0]
 ### Features
   - (Beta) Display Net view (see README)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osc-viewer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "osc-viewer",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@types/cytoscape": "^3.19.9",
         "@vscode/l10n": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "osc-viewer",
   "displayName": "osc-viewer",
   "description": "Viewer of the resource in the 3DS Outscale Cloud",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "l10n": "./l10n",
   "icon": "resources/outscale.png",
   "publisher": "outscale",

--- a/src/network/networkview.ts
+++ b/src/network/networkview.ts
@@ -343,6 +343,25 @@ async function retrieveData(): Promise<CytoscapeNode[] | string | undefined> {
         });
     });
 
+    // VGW
+    net.virtualGateways.forEach((vgw) => {
+        if (typeof vgw.virtualGatewayId === 'undefined') {
+            return undefined;
+        }
+
+        data.push({
+            data: {
+                id: vgw.virtualGatewayId,
+                label: vgw.virtualGatewayId,
+                img: 'design/VirtualPrivateGateway@2x.png',
+                showDetails: true,
+                resourceId: vgw.virtualGatewayId,
+                type: 'VirtualGateway'
+            },
+            group: 'nodes'
+        });
+    });
+
 
     return data;
 


### PR DESCRIPTION
When the routeTable has a link to the VGW, the edge could not be created because the VGW was not handled by the graph.