### PR TITLE
Fix Account details Uri

### DIFF
--- a/src/cloud/mock/account.ts
+++ b/src/cloud/mock/account.ts
@@ -7,7 +7,6 @@ const account: osc.Account = {
 
 export function initMock() {
     const getAccountMock = ImportMock.mockFunction(osc.AccountApi.prototype, 'readAccounts');
-    getAccountMock.onFirstCall().returns(Promise.reject("403"));
     getAccountMock.returns(Promise.resolve(
         {
             accounts: [account],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { OscExplorer } from "./explorer";
 import { ExplorerResourceNode, ResourceNodeType } from './flat/node';
 import { ResourceNode } from './flat/resources/node.resources';
 import { VmResourceNode } from './flat/resources/node.resources.vms';
-import { OscVirtualContentProvider } from './virtual_filesystem/oscvirtualfs';
+import { OscVirtualContentProvider, computeUri } from './virtual_filesystem/oscvirtualfs';
 import { LogsProvider } from './virtual_filesystem/logs';
 import { ProfileNode } from './flat/node.profile';
 import { FolderNode } from './flat/folders/node.folder';
@@ -28,7 +28,7 @@ function getMultipleSelection<T>(mainSelectedItem: T, allSelectedItems?: any[]):
 }
 
 export async function showResourceDetails(profileName: string, resourceType: ResourceNodeType, resourceId: string) {
-    const uri = vscode.Uri.parse('osc:/' + profileName + "/" + resourceType + "/" + resourceId + ".json");
+    const uri = computeUri(profileName, `${resourceType}`, resourceId);
     const doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
     await vscode.window.showTextDocument(doc);
 }
@@ -187,7 +187,7 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     vscode.commands.registerCommand('osc.showAccountInfo', async (arg: ProfileNode) => {
-        const uri = vscode.Uri.parse('osc:/' + arg.profile.name + "/profile/" + arg.profile.name);
+        const uri = computeUri(arg.profile.name, "profile", arg.profile.name);
         try {
             const doc = await vscode.workspace.openTextDocument(uri); // calls back into the provider
             await vscode.window.showTextDocument(doc);

--- a/src/ui-test/treeview.ts
+++ b/src/ui-test/treeview.ts
@@ -307,9 +307,33 @@ describe('ActivityBar', () => {
                     expect(await menu.hasItem(expectedCommandName)).equals(true);
                 });
 
-                it('has show Account Info button', async () => {
+                describe('has show Account Info button', async () => {
                     const expectedCommandName = getButtonTitle("osc.showAccountInfo");
-                    expect(await menu.hasItem(expectedCommandName)).equals(true);
+
+                    after(async () => {
+                        await (new EditorView()).closeAllEditors();
+                    });
+
+                    it("exists", async () => {
+                        expect(await menu.hasItem(expectedCommandName)).equals(true);
+                    });
+
+                    it("shows resource detail when clicking", async () => {
+                        const action = await menu.getItem(expectedCommandName);
+                        await action?.select();
+
+                        await delay(500);
+
+                        // New titles in editor
+                        const editor = new TextEditor();
+                        expect(await editor.getTitle()).equals("first_profile.json");
+                        const data = await editor.getText();
+                        const account = osc.AccountFromJSON(JSON.parse(data));
+                        expect(account.accountId).equals("accountid");
+
+                        const editorView = new EditorView();
+                        await editorView.closeEditor("first_profile.json");
+                    });
                 });
             });
 

--- a/src/virtual_filesystem/oscvirtualfs.ts
+++ b/src/virtual_filesystem/oscvirtualfs.ts
@@ -110,3 +110,7 @@ export class OscVirtualContentProvider implements vscode.TextDocumentContentProv
         return JSON.stringify(resourceEncoding.toString(res), null, 4);
     }
 }
+
+export function computeUri(profile: string, resourceType: string, resourceId: string): vscode.Uri {
+    return vscode.Uri.parse(`osc:/${profile}/${resourceType}/${resourceId}.json`);
+}


### PR DESCRIPTION
Since v0.7.0, the details of account could not be displayed because the URI was not updated. This PR will fix this issue by refactoring the process of computing the URi for Resource Details display.