### PR TITLE
Ignore Focus out on quickPicks

### DIFF
--- a/src/flat/resources/node.resources.routetables.ts
+++ b/src/flat/resources/node.resources.routetables.ts
@@ -61,7 +61,7 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
                 };
             });
 
-            const value = await vscode.window.showQuickPick(pickItems);
+            const value = await vscode.window.showQuickPick(pickItems, { ignoreFocusOut: true });
 
             if (!value) {
                 return Promise.resolve(vscode.l10n.t("Unlink cancelled"));
@@ -98,7 +98,7 @@ export class RouteTableResourceNode extends ResourceNode implements LinkResource
                 };
             });
 
-            const value = await vscode.window.showQuickPick(pickItems);
+            const value = await vscode.window.showQuickPick(pickItems, { ignoreFocusOut: true });
 
             if (!value) {
                 return Promise.resolve(vscode.l10n.t("Deletion of subresource cancelled"));

--- a/src/flat/resources/node.resources.securitygroups.ts
+++ b/src/flat/resources/node.resources.securitygroups.ts
@@ -52,7 +52,7 @@ export class SecurityGroupResourceNode extends ResourceNode implements SubResour
         let rules: osc.SecurityGroupRule[];
         let flow: string;
         if (pickItems.length > 1) {
-            const value = await vscode.window.showQuickPick(pickItems, { title: vscode.l10n.t("Choose the rule category to remove") });
+            const value = await vscode.window.showQuickPick(pickItems, { title: vscode.l10n.t("Choose the rule category to remove"), ignoreFocusOut: true });
             if (!value) {
                 return Promise.resolve(vscode.l10n.t("Deletion of subresource cancelled"));
             }
@@ -77,7 +77,7 @@ export class SecurityGroupResourceNode extends ResourceNode implements SubResour
                 };
             });
 
-            const value = await vscode.window.showQuickPick(pickItems, { title: vscode.l10n.t("Choose the rules to remove"), canPickMany: true });
+            const value = await vscode.window.showQuickPick(pickItems, { title: vscode.l10n.t("Choose the rules to remove"), canPickMany: true, ignoreFocusOut: true });
 
             if (typeof value === 'undefined') {
                 return Promise.resolve(vscode.l10n.t("Deletion of subresource cancelled"));

--- a/src/flat/resources/node.resources.virtualgateways.ts
+++ b/src/flat/resources/node.resources.virtualgateways.ts
@@ -46,7 +46,7 @@ export class VirtualGatewayResourceNode extends ResourceNode implements LinkReso
                 };
             });
 
-            const value = await vscode.window.showQuickPick(pickItems);
+            const value = await vscode.window.showQuickPick(pickItems, { ignoreFocusOut: true });
 
             if (!value) {
                 return Promise.resolve(vscode.l10n.t("Unlink cancelled"));


### PR DESCRIPTION
Ignoring focus out allow users to be able to keep the windows even if they click outside of it

Before:
![before_focus](https://github.com/outscale/vscode-osc-viewer/assets/91073311/c092c8a6-5255-4694-9e8b-346c552d2144)

After:
![after_focus](https://github.com/outscale/vscode-osc-viewer/assets/91073311/95200132-2ca1-4c6a-8321-61ae70af10ce)
